### PR TITLE
Add cultural sensitivity and license checks

### DIFF
--- a/automated_content_testing_system/tests/unit/test_quality_assurance.py
+++ b/automated_content_testing_system/tests/unit/test_quality_assurance.py
@@ -1,0 +1,24 @@
+import importlib
+
+
+def test_flags_offensive_terms():
+    m = importlib.import_module("automated_content_system")
+    QualityAssuranceModule = getattr(m, "QualityAssuranceModule")
+
+    qa = QualityAssuranceModule()
+    report = qa.verify_content({"image_meta": []}, "This text mentions slave labor")
+
+    assert not report.technical_compliance
+    assert any("Offensive terms" in issue for issue in report.issues)
+
+
+def test_flags_unlicensed_images():
+    m = importlib.import_module("automated_content_system")
+    QualityAssuranceModule = getattr(m, "QualityAssuranceModule")
+
+    qa = QualityAssuranceModule()
+    content = {"image_meta": [{"url": "https://img/0", "licensed": False}]}
+    report = qa.verify_content(content, "clean text")
+
+    assert report.copyright_status == "uncertain"
+    assert any("Unlicensed images" in issue for issue in report.issues)

--- a/cultural_terms.txt
+++ b/cultural_terms.txt
@@ -1,0 +1,3 @@
+slave
+savages
+oriental


### PR DESCRIPTION
## Summary
- Introduce `ImageMeta` dataclass for structured image metadata
- Extend QA module with cultural and copyright checks, loading terms from `cultural_terms.txt`
- Convert content pipeline to use `ImageMeta` objects and export metadata
- Export `QualityAssuranceModule` and clarify QA docstring
- Add unit tests for offensive term and unlicensed image detection

## Testing
- `python -m py_compile automated_content_system.py`
- `PYTHONPATH=. pytest -q automated_content_testing_system`


------
https://chatgpt.com/codex/tasks/task_e_68b91a09e14c832f9d4874906ba741bf