### PR TITLE
Add stub multi-platform uploaders

### DIFF
--- a/src/platforms/upload_system.py
+++ b/src/platforms/upload_system.py
@@ -59,12 +59,51 @@ class ThumbnailGenerator:
         return thumb_a, thumb_b
 
 
+class YouTubeUploader:
+    """Stub uploader for YouTube."""
+
+    def upload_video(self, video_path: str, metadata: VideoMetadata) -> UploadResult:
+        return UploadResult(
+            platform="youtube",
+            success=True,
+            video_id="YOUTUBE123",
+            url="http://example.com/youtube",
+        )
+
+
+class TikTokUploader:
+    """Stub uploader for TikTok."""
+
+    def upload_video(self, video_path: str, metadata: VideoMetadata) -> UploadResult:
+        return UploadResult(
+            platform="tiktok",
+            success=True,
+            video_id="TIKTOK123",
+            url="http://example.com/tiktok",
+        )
+
+
+class InstagramUploader:
+    """Stub uploader for Instagram."""
+
+    def upload_video(self, video_path: str, metadata: VideoMetadata) -> UploadResult:
+        return UploadResult(
+            platform="instagram",
+            success=True,
+            video_id="INSTA123",
+            url="http://example.com/instagram",
+        )
+
+
 class MultiPlatformUploader:
     """Minimal uploader that uses the metadata and thumbnail generators."""
 
     def __init__(self):
         self.metadata_generator = MetadataGenerator()
         self.thumbnail_generator = ThumbnailGenerator()
+        self.youtube_uploader = YouTubeUploader()
+        self.tiktok_uploader = TikTokUploader()
+        self.instagram_uploader = InstagramUploader()
 
     def upload_to_all_platforms(
         self,
@@ -77,8 +116,12 @@ class MultiPlatformUploader:
     ) -> List[UploadResult]:
         md = self.metadata_generator.generate_metadata(topic, content_data, script)
         self.thumbnail_generator.generate_thumbnails(topic, image_paths, output_dir)
-        # In real life we'd upload the video. For tests we just return a stub result.
-        return [UploadResult(platform="youtube", success=True, video_id="TEST123", url="http://example.com")]
+        results = [
+            self.youtube_uploader.upload_video(video_path, md),
+            self.tiktok_uploader.upload_video(video_path, md),
+            self.instagram_uploader.upload_video(video_path, md),
+        ]
+        return results
 
 
 __all__ = [

--- a/src/specialized/black_history_content_system/upload_system.py
+++ b/src/specialized/black_history_content_system/upload_system.py
@@ -406,15 +406,45 @@ class YouTubeUploader:
                 self._set_thumbnail(video_id, metadata.thumbnail_b)
             
             logger.info(f"A/B test switch completed for video {video_id}")
-            
+
         except Exception as e:
             logger.error(f"A/B test error: {str(e)}")
 
+
+class TikTokUploader:
+    """Simplified TikTok uploader placeholder."""
+
+    def upload_video(self, video_path: str, metadata: VideoMetadata) -> UploadResult:
+        try:
+            video_id = hashlib.md5(video_path.encode()).hexdigest()[:10]
+            url = f"https://www.tiktok.com/@placeholder/video/{video_id}"
+            logger.info(f"Mock TikTok upload successful: {video_id}")
+            return UploadResult("tiktok", True, video_id=video_id, url=url)
+        except Exception as e:
+            logger.error(f"TikTok upload error: {str(e)}")
+            return UploadResult("tiktok", False, error=str(e))
+
+
+class InstagramUploader:
+    """Simplified Instagram uploader placeholder."""
+
+    def upload_video(self, video_path: str, metadata: VideoMetadata) -> UploadResult:
+        try:
+            video_id = hashlib.md5(video_path.encode()).hexdigest()[:10]
+            url = f"https://www.instagram.com/p/{video_id}/"
+            logger.info(f"Mock Instagram upload successful: {video_id}")
+            return UploadResult("instagram", True, video_id=video_id, url=url)
+        except Exception as e:
+            logger.error(f"Instagram upload error: {str(e)}")
+            return UploadResult("instagram", False, error=str(e))
+
 class MultiPlatformUploader:
     """Orchestrates uploads to multiple platforms"""
-    
+
     def __init__(self):
         self.youtube_uploader = YouTubeUploader()
+        self.tiktok_uploader = TikTokUploader()
+        self.instagram_uploader = InstagramUploader()
         self.metadata_generator = MetadataGenerator()
         self.thumbnail_generator = ThumbnailGenerator()
         
@@ -441,13 +471,18 @@ class MultiPlatformUploader:
             
             # Upload to YouTube
             youtube_result = self.youtube_uploader.upload_video(
-                video_path, metadata, 
+                video_path, metadata,
                 captions_path=os.path.join(output_dir, "captions", "captions.srt")
             )
             results.append(youtube_result)
-            
-            # TODO: Add other platforms (TikTok, Instagram, etc.)
-            # Each platform would have its own uploader class
+
+            # Upload to TikTok
+            tiktok_result = self.tiktok_uploader.upload_video(video_path, metadata)
+            results.append(tiktok_result)
+
+            # Upload to Instagram
+            instagram_result = self.instagram_uploader.upload_video(video_path, metadata)
+            results.append(instagram_result)
             
             # Save upload results
             results_file = os.path.join(output_dir, "upload_results.json")

--- a/tests/unit/test_upload_system.py
+++ b/tests/unit/test_upload_system.py
@@ -13,3 +13,21 @@ def test_thumbnail_generator_api():
     Thumb = getattr(m, "ThumbnailGenerator")
     t = Thumb()
     assert hasattr(t, "generate_thumbnails")
+
+
+def test_multi_platform_uploader_returns_all_platforms(tmp_path):
+    m = importlib.import_module("src.platforms.upload_system")
+    Uploader = getattr(m, "MultiPlatformUploader")
+    uploader = Uploader()
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"data")
+    results = uploader.upload_to_all_platforms(
+        video_path=str(video),
+        topic="History",
+        content_data={"facts": []},
+        script="",
+        image_paths=[],
+        output_dir=str(tmp_path),
+    )
+    platforms = {r.platform for r in results}
+    assert {"youtube", "tiktok", "instagram"} <= platforms


### PR DESCRIPTION
## Summary
- Expand simplified upload system to include TikTok and Instagram stub uploaders
- Add placeholder TikTok and Instagram uploaders to specialized Black History content system
- Test multi-platform uploader returns results for all supported platforms

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbd8f69d68832fa25b7fa2ad1fb082