### PR TITLE
Add service decomposition documents and contracts

### DIFF
--- a/contracts/events/ResearchData@1.0.json
+++ b/contracts/events/ResearchData@1.0.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/events/ResearchData@1.0.json",
+  "title": "ResearchData@1.0",
+  "description": "Event containing findings from topic research.",
+  "type": "object",
+  "required": ["id", "topic_id", "findings"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for this research data set"
+    },
+    "topic_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Identifier of the topic that was researched"
+    },
+    "findings": {
+      "type": "array",
+      "description": "List of key facts or data points gathered",
+      "items": {"type": "string"}
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when research was completed"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/events/ResearchRequest@1.0.json
+++ b/contracts/events/ResearchRequest@1.0.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/events/ResearchRequest@1.0.json",
+  "title": "ResearchRequest@1.0",
+  "description": "Event requesting research for a given topic.",
+  "type": "object",
+  "required": ["id", "topic"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for this request"
+    },
+    "topic": {
+      "$ref": "../schemas/Topic@1.0.json",
+      "description": "Topic to investigate"
+    },
+    "requested_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp when the request was issued"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/events/ScriptDraft@1.0.json
+++ b/contracts/events/ScriptDraft@1.0.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/events/ScriptDraft@1.0.json",
+  "title": "ScriptDraft@1.0",
+  "description": "Event containing a generated script draft.",
+  "type": "object",
+  "required": ["id", "content", "source_research_id"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the script draft"
+    },
+    "content": {
+      "type": "string",
+      "description": "Full text of the drafted script"
+    },
+    "source_research_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "ID of the research data that produced this draft"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the draft was created"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/openapi/orchestrator.yaml
+++ b/contracts/openapi/orchestrator.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.3
+info:
+  title: Orchestrator API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+    description: Production server
+paths:
+  /topics:
+    post:
+      summary: Submit a topic for processing
+      description: Accepts a topic and enqueues it for the research workflow.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Topic'
+      responses:
+        '202':
+          description: Accepted and enqueued
+  /report:
+    get:
+      summary: Fetch analytics report
+      description: Retrieve aggregated analytics for a processed topic.
+      parameters:
+        - in: query
+          name: topic_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      responses:
+        '200':
+          description: Analytics data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  views:
+                    type: integer
+                  likes:
+                    type: integer
+components:
+  schemas:
+    Topic:
+      $ref: '../schemas/Topic@1.0.json'

--- a/contracts/schemas/Topic@1.0.json
+++ b/contracts/schemas/Topic@1.0.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/Topic@1.0.json",
+  "title": "Topic@1.0",
+  "description": "Shared topic data referenced by multiple services.",
+  "type": "object",
+  "required": ["id", "text"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the topic"
+    },
+    "text": {
+      "type": "string",
+      "description": "Raw topic string submitted by a user"
+    },
+    "persona": {
+      "type": "string",
+      "description": "Optional persona or audience targeting information"
+    },
+    "platforms": {
+      "type": "array",
+      "description": "Platforms the content should be produced for",
+      "items": {"type": "string"}
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/adr/ADR-0001-service-decomposition.md
+++ b/docs/adr/ADR-0001-service-decomposition.md
@@ -1,0 +1,19 @@
+# ADR-0001: Service Decomposition
+
+## Status
+Accepted
+
+## Context
+The original repository is a monolithic codebase that couples topic research, script generation, media processing and distribution logic. Scaling individual capabilities independently is difficult and deploys require full‑repo coordination.
+
+## Decision
+Split the monolith into discrete services: topic-research, script-generator, asset-pipeline, tts-service, video-assembly, qa-compliance, metadata-optimizer, uploader-gateway, analytics-collector and a central orchestrator. Services communicate via versioned JSON events on Redis and expose minimal HTTP APIs for control.
+
+## Alternatives
+- **Remain monolithic:** simpler deployment but poor scalability and high coupling.
+- **Partial modularization:** only extract heavy tasks (e.g., video-assembly) which leaves cross‑cutting concerns entangled.
+
+## Consequences
+- Enables independent scaling and deployment of services.
+- Introduces operational complexity; mitigated via docker-compose for local dev and Kubernetes manifests for production.
+- Requires robust contract management and schema versioning.

--- a/docs/modernization/01_service_catalog.md
+++ b/docs/modernization/01_service_catalog.md
@@ -1,0 +1,18 @@
+# Service Catalog
+
+This document enumerates the services that compose the modularized Autonomous Content Creation platform. Each service maps to a single capability from the business plan and exchanges data via versioned events or HTTP APIs.
+
+| Service | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- |
+| topic-research | Accept a topic and perform online research to produce factual and trending data. | `ResearchRequest@1.0` (event) | `ResearchData@1.0` (event) |
+| script-generator | Turn research data into a compelling script. | `ResearchData@1.0` (event) | `ScriptDraft@1.0` (event) |
+| asset-pipeline | Generate images, graphics and B-roll; fetch from stock libraries. | `ScriptDraft@1.0` (event) | `AssetPackage@1.0` (event) |
+| tts-service | Convert the script into voice over segments. | `ScriptDraft@1.0` (event) | `AudioClip@1.0` (event) |
+| video-assembly | Combine assets, audio and video snippets into the final video using FFmpeg/MoviePy. | `AssetPackage@1.0`, `AudioClip@1.0` | `VideoFile@1.0` (event) |
+| qa-compliance | Run quality checks and compliance gates on the final video. | `VideoFile@1.0` (event) | `ApprovedVideo@1.0` or `RejectionReport@1.0` (event) |
+| metadata-optimizer | Generate titles, descriptions, tags and thumbnails. | `ApprovedVideo@1.0` (event) | `Metadata@1.0` (event) |
+| uploader-gateway | Upload the video and metadata to YouTube, TikTok and other platforms using platform-specific rules. | `ApprovedVideo@1.0`, `Metadata@1.0` | `UploadReport@1.0` (event) |
+| analytics-collector | Track performance metrics, viewer engagement and feedback loops for continuous improvement. | Various platform callbacks | `AnalyticsRecord@1.0` (event) |
+| orchestrator | Central coordinator that listens for events and schedules tasks via Celery workers. | All events | orchestrates workflows |
+
+Each service is expected to expose health and readiness endpoints and to communicate asynchronously through Redis or another event bus.

--- a/docs/modernization/02_boundaries_and_events.md
+++ b/docs/modernization/02_boundaries_and_events.md
@@ -1,0 +1,21 @@
+# Service Boundaries and Event Flows
+
+The following diagram illustrates the event-driven architecture for the content system. Solid arrows denote asynchronous events transmitted via Redis (or NATS). Synchronous HTTP calls are labeled accordingly.
+
+```mermaid
+flowchart LR
+  T[Topic Intake]
+  T -- ResearchRequest@1.0 --> R[topic-research]
+  R -- ResearchData@1.0 --> S[script-generator]
+  S -- ScriptDraft@1.0 --> A[asset-pipeline]
+  S -- ScriptDraft@1.0 --> V[tts-service]
+  A -- AssetPackage@1.0 --> C[video-assembly]
+  V -- AudioClip@1.0 --> C
+  C -- VideoFile@1.0 --> Q[qa-compliance]
+  Q -- ApprovedVideo@1.0 --> M[metadata-optimizer]
+  M -- Metadata@1.0 --> U[uploader-gateway]
+  U -- UploadReport@1.0 --> O[analytics-collector]
+  R & S & A & V & C & Q & M & U --> O
+```
+
+All services expose `GET /healthz` for liveness checks. The orchestrator interacts with each service via HTTP for control actions (e.g., `POST /topics`) while publishing and subscribing to the events shown above.


### PR DESCRIPTION
## Summary
- Add descriptions and strict validation to ResearchRequest and ScriptDraft event schemas
- Introduce ResearchData event schema and expand shared Topic schema
- Enhance orchestrator OpenAPI spec with server info, components and UUID query parameter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd97a25a40832f83bbc0fb990fe2d3