### PR TITLE
Add initial service decomposition docs and contracts

### DIFF
--- a/contracts/events/ResearchRequest@1.0.json
+++ b/contracts/events/ResearchRequest@1.0.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tfp-enterprises.com/contracts/events/ResearchRequest@1.0.json",
+  "title": "ResearchRequest",
+  "type": "object",
+  "required": ["topic_id", "query"],
+  "properties": {
+    "topic_id": {"type": "string"},
+    "query": {"type": "string"}
+  }
+}

--- a/contracts/events/ScriptDraft@1.0.json
+++ b/contracts/events/ScriptDraft@1.0.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tfp-enterprises.com/contracts/events/ScriptDraft@1.0.json",
+  "title": "ScriptDraft",
+  "type": "object",
+  "required": ["topic_id", "script"],
+  "properties": {
+    "topic_id": {"type": "string"},
+    "script": {"type": "string"}
+  }
+}

--- a/contracts/events/VideoFile@1.0.json
+++ b/contracts/events/VideoFile@1.0.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tfp-enterprises.com/contracts/events/VideoFile@1.0.json",
+  "title": "VideoFile",
+  "type": "object",
+  "required": ["topic_id", "s3_key"],
+  "properties": {
+    "topic_id": {"type": "string"},
+    "s3_key": {"type": "string"}
+  }
+}

--- a/contracts/openapi/orchestrator.yaml
+++ b/contracts/openapi/orchestrator.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.3
+info:
+  title: Orchestrator API
+  version: '1.0'
+paths:
+  /topics:
+    post:
+      summary: Submit a topic for processing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/Topic@1.0.json'
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  run_id:
+                    type: string
+  /report:
+    get:
+      summary: Retrieve analytics report
+      parameters:
+        - in: query
+          name: video_id
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Analytics report
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  views:
+                    type: integer
+                  likes:
+                    type: integer

--- a/contracts/schemas/Topic@1.0.json
+++ b/contracts/schemas/Topic@1.0.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tfp-enterprises.com/contracts/schemas/Topic@1.0.json",
+  "title": "Topic",
+  "type": "object",
+  "required": ["topic_id", "title"],
+  "properties": {
+    "topic_id": {"type": "string"},
+    "title": {"type": "string"}
+  }
+}

--- a/contracts/schemas/VideoMetadata@1.0.json
+++ b/contracts/schemas/VideoMetadata@1.0.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tfp-enterprises.com/contracts/schemas/VideoMetadata@1.0.json",
+  "title": "VideoMetadata",
+  "type": "object",
+  "required": ["video_id", "title", "description"],
+  "properties": {
+    "video_id": {"type": "string"},
+    "title": {"type": "string"},
+    "description": {"type": "string"}
+  }
+}

--- a/docs/adr/ADR-0001-service-decomposition.md
+++ b/docs/adr/ADR-0001-service-decomposition.md
@@ -1,0 +1,24 @@
+# ADR-0001: Service Decomposition
+
+## Status
+Accepted
+
+## Context
+The existing system is a monolithic repository that bundles research, scripting, asset generation, TTS, video assembly, quality assurance, metadata optimization, uploading and analytics into a single codebase. This coupling makes it difficult to scale individual capabilities or deploy updates independently.
+
+## Decision
+Split the monolith into discrete services corresponding to each major capability. Services communicate via versioned events over Redis/NATS and expose HTTP APIs defined with OpenAPI. A FastAPI orchestrator coordinates workflows and schedules Celery tasks.
+
+## Alternatives Considered
+- **Remain monolithic:** simpler deployment but poor scalability and high coupling.
+- **Partial modularization:** extract only heavy components, leaving others coupled; would still hinder independent deployments.
+
+## Consequences
+- **Pros:** improved scalability, clearer ownership boundaries, ability to deploy and scale services independently.
+- **Cons:** increased operational complexity; requires schema versioning and robust observability.
+
+## Mitigations
+- Use asynchronous queues and idempotent tasks to handle retries safely.
+- Version all schemas and maintain backward compatibility.
+- Centralize logging and metrics for troubleshooting.
+

--- a/docs/modernization/01_service_catalog.md
+++ b/docs/modernization/01_service_catalog.md
@@ -1,0 +1,17 @@
+# Service Catalog
+
+This catalog enumerates the services extracted from the monolithic system. Each service lists its purpose, inputs, outputs, dependencies, expected scale and service-level objectives.
+
+| Service | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- |
+| topic-research | Accept a topic and perform online research to produce factual and trending data. | `ResearchRequest@1.0` (event) | `ResearchData@1.0` (event) |
+| script-generator | Turn research data into a compelling script. | `ResearchData@1.0` (event) | `ScriptDraft@1.0` (event) |
+| asset-pipeline | Generate images, graphics and B-roll; fetch from stock libraries. | `ScriptDraft@1.0` (event); optional API calls to stock providers | `AssetPackage@1.0` (event) |
+| tts-service | Convert the script into voice over segments. | `ScriptDraft@1.0` (event) | `AudioClip@1.0` (event) |
+| video-assembly | Combine assets and audio into the final video using FFmpeg/MoviePy. | `AssetPackage@1.0`, `AudioClip@1.0` (events) | `VideoFile@1.0` (event) |
+| qa-compliance | Run quality checks and compliance gates on the final video. | `VideoFile@1.0` (event) | `ApprovedVideo@1.0` or `RejectionReport@1.0` (events) |
+| metadata-optimizer | Generate titles, descriptions, tags and thumbnails. | `ApprovedVideo@1.0` (event) | `Metadata@1.0` (event) |
+| uploader-gateway | Upload the video and metadata to platforms like YouTube and TikTok using platform rules. | `ApprovedVideo@1.0`, `Metadata@1.0` (events) | `UploadReport@1.0` (event) |
+| analytics-collector | Track performance metrics, viewer engagement and feedback loops for continuous improvement. | Platform callbacks | `AnalyticsRecord@1.0` (event) |
+| orchestrator | Central coordinator that listens for events and schedules tasks via Celery workers. | All events | Orchestrates workflows |
+

--- a/docs/modernization/02_boundaries_and_events.md
+++ b/docs/modernization/02_boundaries_and_events.md
@@ -1,0 +1,21 @@
+# Service Boundaries and Events
+
+The diagram below illustrates service boundaries, data flows and event channels in the content system.
+
+```mermaid
+flowchart LR
+  T[Topic Intake] -- ResearchRequest@1.0 --> R[topic-research]
+  R -- ResearchData@1.0 --> S[script-generator]
+  S -- ScriptDraft@1.0 --> A[asset-pipeline]
+  S -- ScriptDraft@1.0 --> V[tts-service]
+  A -- AssetPackage@1.0 --> C[video-assembly]
+  V -- AudioClip@1.0 --> C
+  C -- VideoFile@1.0 --> Q[qa-compliance]
+  Q -- ApprovedVideo@1.0 --> M[metadata-optimizer]
+  M -- Metadata@1.0 --> U[uploader-gateway]
+  U -- UploadReport@1.0 --> O[analytics-collector]
+  R & S & A & V & C & Q & M & U --> O
+```
+
+Interactions between services use asynchronous events over Redis/NATS. Synchronous interactions, such as topic submission or analytics retrieval, are exposed via HTTP APIs defined with OpenAPI.
+


### PR DESCRIPTION
## Summary
- document initial service catalog and boundaries for modular content system
- add ADR for service decomposition
- provide sample OpenAPI spec and event schemas

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd9dd8ac6c832f9e01ac72d4fc19f8