### PR TITLE
feat: centralize API credential loading

### DIFF
--- a/src/core/automated_content_system.py
+++ b/src/core/automated_content_system.py
@@ -191,9 +191,10 @@ class QualityAssuranceModule:
 class AutomatedContentSystem:
     """Deterministic content pipeline suitable for tests."""
 
-    def __init__(self, config: ContentConfig, pexels_api_key: Optional[str] = None) -> None:
+    def __init__(self, config: ContentConfig, service_config: Optional[Dict[str, str]] = None) -> None:
         self.config = config
-        self.pexels_api_key = pexels_api_key
+        self.service_config = service_config or {}
+        self.pexels_api_key = self.service_config.get("PEXELS_API_KEY")
         self.research_engine = ContentResearchEngine()
         self.image_manager = ImageManager()
         self.voice_synthesizer = VoiceSynthesizer()

--- a/src/core/content_system.py
+++ b/src/core/content_system.py
@@ -154,10 +154,19 @@ class ContentResearchEngine:
         return list(set(keywords[:5]))  # Return unique keywords, limit to 5
 
 class ImageAssetManager:
-    """Manages image sourcing from free APIs"""
-    
-    def __init__(self, pexels_api_key: str = None):
-        self.pexels_api_key = pexels_api_key or os.getenv('PEXELS_API_KEY')
+    """Manages image sourcing from free APIs."""
+
+    def __init__(self, config: Optional[Dict[str, str]] = None):
+        """Create a new manager using credentials from ``config``.
+
+        Parameters
+        ----------
+        config:
+            Optional mapping containing API credentials such as
+            ``{"PEXELS_API_KEY": "..."}``.
+        """
+        self.config = config or {}
+        self.pexels_api_key = self.config.get("PEXELS_API_KEY") or self.config.get("pexels_api_key")
         self.session = requests.Session()
         
     def get_images_for_topic(self, keywords: List[str], count: int = 5) -> List[str]:
@@ -460,12 +469,12 @@ class QualityAssurance:
             return 0.5
 
 class AutomatedContentSystem:
-    """Main orchestrator for automated content creation"""
-    
-    def __init__(self, config: ContentConfig, pexels_api_key: str = None):
+    """Main orchestrator for automated content creation."""
+
+    def __init__(self, config: ContentConfig, service_config: Optional[Dict[str, str]] = None):
         self.config = config
         self.research_engine = ContentResearchEngine()
-        self.image_manager = ImageAssetManager(pexels_api_key)
+        self.image_manager = ImageAssetManager(service_config)
         self.voice_synthesizer = VoiceSynthesizer()
         self.video_engine = VideoAssemblyEngine(config)
         self.qa_module = QualityAssurance()

--- a/tests/integration/test_research_to_script.py
+++ b/tests/integration/test_research_to_script.py
@@ -1,5 +1,6 @@
 import importlib
 import pytest
+from src.cloud.config_sync import load_credentials
 
 @pytest.mark.timeout(20)
 def test_research_to_script_flow(monkeypatch):
@@ -18,7 +19,8 @@ def test_research_to_script_flow(monkeypatch):
 
     # Use the system which uses research internally
     cfg = acs.ContentConfig(topic="X", duration=6.0)
-    sys = acs.AutomatedContentSystem(cfg, pexels_api_key=None)
+    creds = load_credentials(["PEXELS_API_KEY"])
+    sys = acs.AutomatedContentSystem(cfg, creds)
 
     # Monkeypatch internal research call to return our data
     monkeypatch.setattr(sys, "research_engine", research)

--- a/tests/integration/test_video_assembly_flow.py
+++ b/tests/integration/test_video_assembly_flow.py
@@ -1,11 +1,13 @@
 import importlib
 import pytest
+from src.cloud.config_sync import load_credentials
 
 @pytest.mark.timeout(20)
 def test_video_assembly_path_exists(monkeypatch):
     acs = importlib.import_module("src.core.automated_content_system")
     cfg = acs.ContentConfig(topic="Y", duration=5.0)
-    sys = acs.AutomatedContentSystem(cfg, pexels_api_key=None)
+    creds = load_credentials(["PEXELS_API_KEY"])
+    sys = acs.AutomatedContentSystem(cfg, creds)
 
     # Mock everything heavy
     monkeypatch.setattr(sys.research_engine, "research_topic", lambda topic, **k: {

--- a/tests/nonfunctional/test_performance_timings.py
+++ b/tests/nonfunctional/test_performance_timings.py
@@ -1,10 +1,12 @@
 import importlib, time, pytest
+from src.cloud.config_sync import load_credentials
 
 @pytest.mark.timeout(120)
 def test_single_video_under_target(monkeypatch):
     acs = importlib.import_module("src.core.automated_content_system")
     cfg = acs.ContentConfig(topic="Perf Test", duration=5.0)
-    sys = acs.AutomatedContentSystem(cfg, pexels_api_key=None)
+    creds = load_credentials(["PEXELS_API_KEY"])
+    sys = acs.AutomatedContentSystem(cfg, creds)
 
     # Mock heavy network interactions
     monkeypatch.setattr(sys.research_engine, "research_topic", lambda topic, **k: {

--- a/tests/qa_runner/run_suite.py
+++ b/tests/qa_runner/run_suite.py
@@ -2,6 +2,7 @@
 import argparse, os, sys, time, json, pathlib, yaml
 from importlib import import_module
 from .scenario_models import Suite
+from src.cloud.config_sync import load_credentials
 
 def _import_or_exit(module_name, hint):
     try:
@@ -15,7 +16,8 @@ def run_smoke(step, cfg):
     ContentConfig = getattr(mod, "ContentConfig")
     AutomatedContentSystem = getattr(mod, "AutomatedContentSystem")
     config = ContentConfig(topic=cfg.topic or "Test Topic", duration=float(cfg.duration or 20))
-    system = AutomatedContentSystem(config)
+    creds = load_credentials(["PEXELS_API_KEY"])
+    system = AutomatedContentSystem(config, creds)
     ok, result = system.create_content(cfg.topic or "Test Topic")
     if not ok:
         raise RuntimeError(f"create_content failed: {result}")

--- a/tests/unit/test_content_system.py
+++ b/tests/unit/test_content_system.py
@@ -1,5 +1,6 @@
 import importlib
 import pytest
+from src.cloud.config_sync import load_credentials
 
 def test_automated_content_system_imports():
     m = importlib.import_module("src.core.automated_content_system")
@@ -13,7 +14,8 @@ def test_create_content_smoke(monkeypatch):
 
     # Force image downloads to be skipped by faking URLs and downloader
     config = ContentConfig(topic="Test", duration=5.0)
-    sys = System(config, pexels_api_key=None)
+    creds = load_credentials(["PEXELS_API_KEY"])
+    sys = System(config, creds)
 
     # Monkeypatch image manager to return a local placeholder list
     if hasattr(sys, "image_manager"):


### PR DESCRIPTION
## Summary
- add `load_credentials` helper to fetch secrets from AWS Parameter Store with environment fallback
- inject credential config into `ImageAssetManager` and `AutomatedContentSystem`
- update tests and QA runner to supply credentials via loader

## Testing
- `pytest tests/unit tests/integration tests/nonfunctional -q`

------
https://chatgpt.com/codex/tasks/task_e_68c15abe905c832f9e7cfc5d8f9c71a5