### PR TITLE
feat: add resilient network helper

### DIFF
--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -9,5 +9,7 @@ anyio>=4.4
 pydantic>=2.8
 pyyaml>=6.0
 types-PyYAML>=6.0.12
+# for retrying network operations
+tenacity>=8.2
 # for optional video and audio probing without full render
 tinytag>=1.10


### PR DESCRIPTION
## Summary
- add `_get_with_retry` helper with timeout and exponential backoff
- apply retry helper to Wikipedia search and image fetching
- record `tenacity` test dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c15abf75b0832f9fd2fdeb278dba38