### PR TITLE
feat: centralize json logging configuration

### DIFF
--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -302,13 +302,10 @@ from omnichannel_implementation import OmnichannelOrchestrator
 from platform_apis import OmnichannelUploadManager
 from advanced_optimization import ABTestManager, PredictiveOptimizer
 from monitoring_analytics import RealTimeMonitor, MONITORING_CONFIG
+from src.core.logging_config import get_logger
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s'
-)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class CompleteOmnichannelSystem:
     """Complete integrated omnichannel content system"""

--- a/scripts/complete_example.py
+++ b/scripts/complete_example.py
@@ -19,7 +19,8 @@ import sqlite3
 from datetime import datetime, timedelta
 from typing import Dict, List, Tuple
 from pathlib import Path
-import logging
+
+from src.core.logging_config import get_logger
 
 # Import our custom modules (these would be the files we created above)
 try:
@@ -136,15 +137,7 @@ class ContentBusinessManager:
     
     def setup_logging(self):
         """Set up comprehensive logging"""
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            handlers=[
-                logging.FileHandler('content_business.log'),
-                logging.StreamHandler()
-            ]
-        )
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger(__name__)
     
     def get_daily_topics(self) -> List[Dict]:
         """Generate daily content topics based on niche strategy"""

--- a/scripts/workiy_main_execution.py
+++ b/scripts/workiy_main_execution.py
@@ -11,7 +11,6 @@ import sqlite3
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple
-import logging
 
 # Import our specialized modules
 from src.specialized.black_history_content_system.scripts.historical_research_engine import HistoricalResearchEngine
@@ -19,6 +18,7 @@ from src.specialized.black_history_content_system.scripts.historical_script_gene
 from src.specialized.black_history_content_system.scripts.historical_qa_system import HistoricalQualityAssurance
 from src.core.content_system import AutomatedContentSystem, ContentConfig
 from src.platforms.upload_system import MultiPlatformUploader
+from src.core.logging_config import get_logger
 
 class HistoricalContentBusinessSystem:
     """Complete system for creating historical educational content"""
@@ -40,15 +40,7 @@ class HistoricalContentBusinessSystem:
     
     def setup_logging(self):
         """Setup comprehensive logging"""
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            handlers=[
-                logging.FileHandler('logs/historical_content.log'),
-                logging.StreamHandler()
-            ]
-        )
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger(__name__)
         self.logger.info("Historical Content System initialized")
     
     def load_configuration(self):

--- a/src/automation/monitoring_analytics.py
+++ b/src/automation/monitoring_analytics.py
@@ -7,7 +7,6 @@ Complete monitoring, alerting, and analytics for omnichannel content
 import asyncio
 import aiohttp
 import json
-import logging
 import time
 from datetime import datetime, timedelta
 from dataclasses import dataclass, asdict
@@ -24,7 +23,9 @@ import schedule
 import threading
 import os
 
-logger = logging.getLogger(__name__)
+from src.core.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 @dataclass
 class AlertRule:
@@ -851,10 +852,4 @@ async def main():
     print("✅ Monitoring system stopped gracefully")
 
 if __name__ == "__main__":
-    # Set up logging
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    )
-    
     asyncio.run(main())

--- a/src/core/content_system.py
+++ b/src/core/content_system.py
@@ -19,7 +19,6 @@ import os
 import json
 import time
 import hashlib
-import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
@@ -33,13 +32,10 @@ from moviepy.editor import *
 from PIL import Image
 import tempfile
 
-# Setup logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.FileHandler('content_creation.log'), logging.StreamHandler()]
-)
-logger = logging.getLogger(__name__)
+from .logging_config import get_logger
+
+# Setup logging using shared configuration
+logger = get_logger(__name__)
 
 @dataclass
 class ContentConfig:

--- a/src/core/logging_config.py
+++ b/src/core/logging_config.py
@@ -1,0 +1,98 @@
+"""Central logging configuration for the project.
+
+This module exposes ``configure_logging`` and ``get_logger`` helpers that
+set up a JSON formatted logging configuration using ``logging.config.dictConfig``.
+Configuration is driven by environment variables so the verbosity and the
+location of log files can be adjusted without code changes.
+
+Environment variables:
+
+``LOG_LEVEL``        - Logging level (default ``INFO``)
+``LOG_FILE``         - File path for the rotating file handler (default ``app.log``)
+``LOG_MAX_BYTES``    - Maximum bytes per log file before rotation (default ``1048576``)
+``LOG_BACKUP_COUNT`` - Number of rotated files to keep (default ``3``)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import logging.config
+import os
+from typing import Optional
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        log_record = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exception"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+_CONFIGURED = False
+
+
+def configure_logging() -> None:
+    """Configure logging for the application.
+
+    Uses ``logging.config.dictConfig`` to apply a JSON formatter, a console
+    handler and a rotating file handler. The logging level and file location
+    are controlled via environment variables.
+    """
+
+    global _CONFIGURED
+    if _CONFIGURED:
+        return
+
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    log_file = os.getenv("LOG_FILE", "app.log")
+    max_bytes = int(os.getenv("LOG_MAX_BYTES", 1_048_576))
+    backup_count = int(os.getenv("LOG_BACKUP_COUNT", 3))
+
+    config = {
+        "version": 1,
+        "formatters": {
+            "json": {
+                "()": JsonFormatter,
+                "datefmt": "%Y-%m-%dT%H:%M:%S",
+            }
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "level": log_level,
+                "formatter": "json",
+            },
+            "file": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "level": log_level,
+                "formatter": "json",
+                "filename": log_file,
+                "maxBytes": max_bytes,
+                "backupCount": backup_count,
+            },
+        },
+        "root": {
+            "level": log_level,
+            "handlers": ["console", "file"],
+        },
+    }
+
+    logging.config.dictConfig(config)
+    _CONFIGURED = True
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a module-level logger configured for JSON output."""
+
+    configure_logging()
+    return logging.getLogger(name)
+

--- a/src/platforms/platform_apis.py
+++ b/src/platforms/platform_apis.py
@@ -10,9 +10,10 @@ import json
 import base64
 import os
 from typing import Dict, List, Optional
+
+from src.core.logging_config import get_logger
 from dataclasses import dataclass
 from datetime import datetime
-import logging
 
 # Google APIs for YouTube
 from googleapiclient.discovery import build
@@ -21,7 +22,7 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class UploadResult:

--- a/src/quality/process_guardian.py
+++ b/src/quality/process_guardian.py
@@ -18,12 +18,13 @@ in a background thread.  Logs are emitted to both STDOUT and a file
 named ``process_guardian.log``.
 """
 
-import logging
 import subprocess
 import threading
 import time
 from dataclasses import dataclass
 from typing import List, Optional
+
+from src.core.logging_config import get_logger
 
 
 @dataclass
@@ -40,15 +41,7 @@ class ProcessGuardian:
 
     def __init__(self, specs: List[ProcessSpec]):
         self.specs = specs
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            handlers=[
-                logging.FileHandler("process_guardian.log"),
-                logging.StreamHandler(),
-            ],
-        )
-        self.log = logging.getLogger(__name__)
+        self.log = get_logger(__name__)
 
     def _monitor(self, spec: ProcessSpec) -> None:
         restarts = 0

--- a/src/specialized/black_history_content_system/content_system.py
+++ b/src/specialized/black_history_content_system/content_system.py
@@ -19,7 +19,6 @@ import os
 import json
 import time
 import hashlib
-import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
@@ -33,13 +32,10 @@ from moviepy.editor import *
 from PIL import Image
 import tempfile
 
-# Setup logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.FileHandler('content_creation.log'), logging.StreamHandler()]
-)
-logger = logging.getLogger(__name__)
+from src.core.logging_config import get_logger
+
+# Setup logging using shared configuration
+logger = get_logger(__name__)
 
 @dataclass
 class ContentConfig:

--- a/src/specialized/black_history_content_system/main_historical_content_system.py
+++ b/src/specialized/black_history_content_system/main_historical_content_system.py
@@ -11,7 +11,6 @@ import sqlite3
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple
-import logging
 
 # Import our specialized modules
 from scripts.historical_research_engine import HistoricalResearchEngine
@@ -19,6 +18,7 @@ from scripts.historical_script_generator import HistoricalScriptGenerator
 from scripts.historical_qa_system import HistoricalQualityAssurance
 from src.core.content_system import AutomatedContentSystem, ContentConfig
 from src.platforms.upload_system import MultiPlatformUploader
+from src.core.logging_config import get_logger
 
 class HistoricalContentBusinessSystem:
     """Complete system for creating historical educational content"""
@@ -40,15 +40,7 @@ class HistoricalContentBusinessSystem:
     
     def setup_logging(self):
         """Setup comprehensive logging"""
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            handlers=[
-                logging.FileHandler('logs/historical_content.log'),
-                logging.StreamHandler()
-            ]
-        )
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger(__name__)
         self.logger.info("Historical Content System initialized")
     
     def load_configuration(self):


### PR DESCRIPTION
## Summary
- add shared logging config with JSON formatter, rotating file handler, and env-driven log levels
- switch core, automation, platform, quality, and specialized modules to the shared logger
- update docs and example scripts to reflect new logging setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c15ac0bab0832fb79b305c4bd8dd1f